### PR TITLE
Add service account dependency

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -82,199 +82,199 @@ resource "aws_iam_policy" "this" {
   # We use a heredoc for the policy JSON so that we can more easily diff and
   # copy/paste from upstream.
   # Source: `curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.1.0/docs/install/iam_policy.json`
-  policy = <<POLICY
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "iam:CreateServiceLinkedRole",
-                "ec2:DescribeAccountAttributes",
-                "ec2:DescribeAddresses",
-                "ec2:DescribeInternetGateways",
-                "ec2:DescribeVpcs",
-                "ec2:DescribeSubnets",
-                "ec2:DescribeSecurityGroups",
-                "ec2:DescribeInstances",
-                "ec2:DescribeNetworkInterfaces",
-                "ec2:DescribeTags",
-                "elasticloadbalancing:DescribeLoadBalancers",
-                "elasticloadbalancing:DescribeLoadBalancerAttributes",
-                "elasticloadbalancing:DescribeListeners",
-                "elasticloadbalancing:DescribeListenerCertificates",
-                "elasticloadbalancing:DescribeSSLPolicies",
-                "elasticloadbalancing:DescribeRules",
-                "elasticloadbalancing:DescribeTargetGroups",
-                "elasticloadbalancing:DescribeTargetGroupAttributes",
-                "elasticloadbalancing:DescribeTargetHealth",
-                "elasticloadbalancing:DescribeTags"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "cognito-idp:DescribeUserPoolClient",
-                "acm:ListCertificates",
-                "acm:DescribeCertificate",
-                "iam:ListServerCertificates",
-                "iam:GetServerCertificate",
-                "waf-regional:GetWebACL",
-                "waf-regional:GetWebACLForResource",
-                "waf-regional:AssociateWebACL",
-                "waf-regional:DisassociateWebACL",
-                "wafv2:GetWebACL",
-                "wafv2:GetWebACLForResource",
-                "wafv2:AssociateWebACL",
-                "wafv2:DisassociateWebACL",
-                "shield:GetSubscriptionState",
-                "shield:DescribeProtection",
-                "shield:CreateProtection",
-                "shield:DeleteProtection"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:RevokeSecurityGroupIngress"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:CreateSecurityGroup"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:CreateTags"
-            ],
-            "Resource": "arn:aws:ec2:*:*:security-group/*",
-            "Condition": {
-                "StringEquals": {
-                    "ec2:CreateAction": "CreateSecurityGroup"
-                },
-                "Null": {
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:CreateTags",
-                "ec2:DeleteTags"
-            ],
-            "Resource": "arn:aws:ec2:*:*:security-group/*",
-            "Condition": {
-                "Null": {
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
-                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:RevokeSecurityGroupIngress",
-                "ec2:DeleteSecurityGroup"
-            ],
-            "Resource": "*",
-            "Condition": {
-                "Null": {
-                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:CreateLoadBalancer",
-                "elasticloadbalancing:CreateTargetGroup"
-            ],
-            "Resource": "*",
-            "Condition": {
-                "Null": {
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:CreateListener",
-                "elasticloadbalancing:DeleteListener",
-                "elasticloadbalancing:CreateRule",
-                "elasticloadbalancing:DeleteRule"
-            ],
-            "Resource": "*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:AddTags",
-                "elasticloadbalancing:RemoveTags"
-            ],
-            "Resource": [
-                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
-                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
-                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
-            ],
-            "Condition": {
-                "Null": {
-                    "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
-                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:ModifyLoadBalancerAttributes",
-                "elasticloadbalancing:SetIpAddressType",
-                "elasticloadbalancing:SetSecurityGroups",
-                "elasticloadbalancing:SetSubnets",
-                "elasticloadbalancing:DeleteLoadBalancer",
-                "elasticloadbalancing:ModifyTargetGroup",
-                "elasticloadbalancing:ModifyTargetGroupAttributes",
-                "elasticloadbalancing:DeleteTargetGroup"
-            ],
-            "Resource": "*",
-            "Condition": {
-                "Null": {
-                    "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
-                }
-            }
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:RegisterTargets",
-                "elasticloadbalancing:DeregisterTargets"
-            ],
-            "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "elasticloadbalancing:SetWebAcl",
-                "elasticloadbalancing:ModifyListener",
-                "elasticloadbalancing:AddListenerCertificates",
-                "elasticloadbalancing:RemoveListenerCertificates",
-                "elasticloadbalancing:ModifyRule"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-POLICY
+  policy = <<-POLICY
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "iam:CreateServiceLinkedRole",
+                  "ec2:DescribeAccountAttributes",
+                  "ec2:DescribeAddresses",
+                  "ec2:DescribeInternetGateways",
+                  "ec2:DescribeVpcs",
+                  "ec2:DescribeSubnets",
+                  "ec2:DescribeSecurityGroups",
+                  "ec2:DescribeInstances",
+                  "ec2:DescribeNetworkInterfaces",
+                  "ec2:DescribeTags",
+                  "elasticloadbalancing:DescribeLoadBalancers",
+                  "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                  "elasticloadbalancing:DescribeListeners",
+                  "elasticloadbalancing:DescribeListenerCertificates",
+                  "elasticloadbalancing:DescribeSSLPolicies",
+                  "elasticloadbalancing:DescribeRules",
+                  "elasticloadbalancing:DescribeTargetGroups",
+                  "elasticloadbalancing:DescribeTargetGroupAttributes",
+                  "elasticloadbalancing:DescribeTargetHealth",
+                  "elasticloadbalancing:DescribeTags"
+              ],
+              "Resource": "*"
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "cognito-idp:DescribeUserPoolClient",
+                  "acm:ListCertificates",
+                  "acm:DescribeCertificate",
+                  "iam:ListServerCertificates",
+                  "iam:GetServerCertificate",
+                  "waf-regional:GetWebACL",
+                  "waf-regional:GetWebACLForResource",
+                  "waf-regional:AssociateWebACL",
+                  "waf-regional:DisassociateWebACL",
+                  "wafv2:GetWebACL",
+                  "wafv2:GetWebACLForResource",
+                  "wafv2:AssociateWebACL",
+                  "wafv2:DisassociateWebACL",
+                  "shield:GetSubscriptionState",
+                  "shield:DescribeProtection",
+                  "shield:CreateProtection",
+                  "shield:DeleteProtection"
+              ],
+              "Resource": "*"
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ec2:AuthorizeSecurityGroupIngress",
+                  "ec2:RevokeSecurityGroupIngress"
+              ],
+              "Resource": "*"
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ec2:CreateSecurityGroup"
+              ],
+              "Resource": "*"
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ec2:CreateTags"
+              ],
+              "Resource": "arn:aws:ec2:*:*:security-group/*",
+              "Condition": {
+                  "StringEquals": {
+                      "ec2:CreateAction": "CreateSecurityGroup"
+                  },
+                  "Null": {
+                      "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                  }
+              }
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ec2:CreateTags",
+                  "ec2:DeleteTags"
+              ],
+              "Resource": "arn:aws:ec2:*:*:security-group/*",
+              "Condition": {
+                  "Null": {
+                      "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                      "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                  }
+              }
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "ec2:AuthorizeSecurityGroupIngress",
+                  "ec2:RevokeSecurityGroupIngress",
+                  "ec2:DeleteSecurityGroup"
+              ],
+              "Resource": "*",
+              "Condition": {
+                  "Null": {
+                      "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                  }
+              }
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "elasticloadbalancing:CreateLoadBalancer",
+                  "elasticloadbalancing:CreateTargetGroup"
+              ],
+              "Resource": "*",
+              "Condition": {
+                  "Null": {
+                      "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
+                  }
+              }
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "elasticloadbalancing:CreateListener",
+                  "elasticloadbalancing:DeleteListener",
+                  "elasticloadbalancing:CreateRule",
+                  "elasticloadbalancing:DeleteRule"
+              ],
+              "Resource": "*"
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "elasticloadbalancing:AddTags",
+                  "elasticloadbalancing:RemoveTags"
+              ],
+              "Resource": [
+                  "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                  "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                  "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+              ],
+              "Condition": {
+                  "Null": {
+                      "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+                      "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                  }
+              }
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                  "elasticloadbalancing:SetIpAddressType",
+                  "elasticloadbalancing:SetSecurityGroups",
+                  "elasticloadbalancing:SetSubnets",
+                  "elasticloadbalancing:DeleteLoadBalancer",
+                  "elasticloadbalancing:ModifyTargetGroup",
+                  "elasticloadbalancing:ModifyTargetGroupAttributes",
+                  "elasticloadbalancing:DeleteTargetGroup"
+              ],
+              "Resource": "*",
+              "Condition": {
+                  "Null": {
+                      "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                  }
+              }
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "elasticloadbalancing:RegisterTargets",
+                  "elasticloadbalancing:DeregisterTargets"
+              ],
+              "Resource": "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*"
+          },
+          {
+              "Effect": "Allow",
+              "Action": [
+                  "elasticloadbalancing:SetWebAcl",
+                  "elasticloadbalancing:ModifyListener",
+                  "elasticloadbalancing:AddListenerCertificates",
+                  "elasticloadbalancing:RemoveListenerCertificates",
+                  "elasticloadbalancing:ModifyRule"
+              ],
+              "Resource": "*"
+          }
+      ]
+  }
+  POLICY
 }
 
 resource "aws_iam_role_policy_attachment" "this" {
@@ -451,19 +451,19 @@ resource "null_resource" "supply_target_group_arns" {
     environment = {
       KUBECONFIG = base64encode(data.template_file.kubeconfig.rendered)
     }
-    command = <<EOF
-cat <<YAML | kubectl -n ${var.k8s_namespace} --kubeconfig <(echo $KUBECONFIG | base64 --decode) apply -f -
-apiVersion: elbv2.k8s.aws/v1beta1
-kind: TargetGroupBinding
-metadata:
-  name:
-spec:
-  serviceRef:
-    name: awesome-service # route traffic to the awesome-service
-    port: 80
-  targetGroupARN: ${var.alb_target_group_arns}
-YAML
-EOF
+    command = <<-EOF
+      cat <<YAML | kubectl -n ${var.k8s_namespace} --kubeconfig <(echo $KUBECONFIG | base64 --decode) apply -f -
+      apiVersion: elbv2.k8s.aws/v1beta1
+      kind: TargetGroupBinding
+      metadata:
+        name:
+      spec:
+        serviceRef:
+          name: awesome-service # route traffic to the awesome-service
+          port: 80
+        targetGroupARN: ${var.alb_target_group_arns}
+      YAML
+    EOF
   }
   depends_on = [helm_release.alb_controller]
 }

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,11 @@
 locals {
-  alb_controller_helm_repo    = "https://aws.github.io/eks-charts"
-  alb_controller_chart_name   = "aws-load-balancer-controller"
-  alb_controller_chart_version      = var.aws_load_balancer_controller_chart_version
-  aws_alb_ingress_class                   = "alb"
-  aws_vpc_id                              = data.aws_vpc.selected.id
-  aws_region_name                         = data.aws_region.current.name
-  aws_iam_path_prefix                     = var.aws_iam_path_prefix == "" ? null : var.aws_iam_path_prefix
+  alb_controller_helm_repo     = "https://aws.github.io/eks-charts"
+  alb_controller_chart_name    = "aws-load-balancer-controller"
+  alb_controller_chart_version = var.aws_load_balancer_controller_chart_version
+  aws_alb_ingress_class        = "alb"
+  aws_vpc_id                   = data.aws_vpc.selected.id
+  aws_region_name              = data.aws_region.current.name
+  aws_iam_path_prefix          = var.aws_iam_path_prefix == "" ? null : var.aws_iam_path_prefix
 }
 
 data "aws_vpc" "selected" {
@@ -82,7 +82,7 @@ resource "aws_iam_policy" "this" {
   # We use a heredoc for the policy JSON so that we can more easily diff and
   # copy/paste from upstream.
   # Source: `curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.1.0/docs/install/iam_policy.json`
-  policy      = <<POLICY
+  policy = <<POLICY
 {
     "Version": "2012-10-17",
     "Statement": [
@@ -440,7 +440,7 @@ data "template_file" "kubeconfig" {
 # Since the kubernetes_provider cannot yet handle CRDs, we need to set any
 # supplied TargetGroupBinding using a null_resource.
 #
-# The method use below for securely specifying the kubeconfig to provisioners
+# The method used below for securely specifying the kubeconfig to provisioners
 # without spilling secrets into the logs comes from:
 # https://medium.com/citihub/a-more-secure-way-to-call-kubectl-from-terraform-1052adf37af8
 
@@ -451,7 +451,7 @@ resource "null_resource" "supply_target_group_arns" {
     environment = {
       KUBECONFIG = base64encode(data.template_file.kubeconfig.rendered)
     }
-    command     = <<EOF
+    command = <<EOF
 cat <<YAML | kubectl -n ${var.k8s_namespace} --kubeconfig <(echo $KUBECONFIG | base64 --decode) apply -f -
 apiVersion: elbv2.k8s.aws/v1beta1
 kind: TargetGroupBinding


### PR DESCRIPTION
Previously the `helm_release` set the `serviceAccount.name` using a string, rather than a reference to the name of the `kubernetes_service_account` resource. This meant it was possible for the helm_release to try to use the service account before it exists. 

Our hypothesis is that was the source of errors like:
`
Error: Post "https://7B9E8D62B2EED87B94EF84EACD8D17C1.sk1.***.eks.amazonaws.com/api/v1/namespaces/kube-system/serviceaccounts": dial tcp 54.221.223.176:443: i/o timeout  on .terraform/modules/instance.aws_load_balancer_controller/main.tf line 285, in resource "kubernetes_service_account" "this": 285: resource "kubernetes_service_account" "this" {Error: Post "https://7B9E8D62B2EED87B94EF84EACD8D17C1.sk1.***.eks.amazonaws.com/apis/rbac.authorization.k8s.io/v1/clusterroles": dial tcp 34.237.244.203:443: i/o timeout  on .terraform/modules/instance.aws_load_balancer_controller/main.tf line 303, in resource "kubernetes_cluster_role" "this": 303: resource "kubernetes_cluster_role" "this" {Error: release aws-load-balancer-controller failed, and has been uninstalled due to atomic being set: timed out waiting for the condition  on .terraform/modules/instance.aws_load_balancer_controller/main.tf line 384, in resource "helm_release" "using_iamserviceaccount": 384: resource "helm_release" "using_iamserviceaccount" { exit status 1
`

🤞 that this eliminates those!