### PR TITLE
Delay attempting to create the service account and cluster role

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -298,6 +298,7 @@ resource "kubernetes_service_account" "this" {
       "app.kubernetes.io/managed-by" = "terraform"
     }
   }
+  depends_on = [var.alb_controller_depends_on]
 }
 
 resource "kubernetes_cluster_role" "this" {
@@ -355,6 +356,7 @@ resource "kubernetes_cluster_role" "this" {
       "watch",
     ]
   }
+  depends_on = [var.alb_controller_depends_on]
 }
 
 resource "kubernetes_cluster_role_binding" "this" {


### PR DESCRIPTION
Ensure that callers have an opportunity to make the entire module wait on readiness of the target cluster