### PR TITLE
Make cr customizable and allow multiple target groups

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -440,7 +440,7 @@ data "template_file" "kubeconfig" {
 # https://medium.com/citihub/a-more-secure-way-to-call-kubectl-from-terraform-1052adf37af8
 
 resource "null_resource" "supply_target_group_arns" {
-  count = (var.alb_target_group_arns != "") ? 1 : 0
+  count = (length(var.target_groups) > 0) ? length(var.target_groups) : 0
   provisioner "local-exec" {
     interpreter = ["/bin/bash", "-c"]
     environment = {
@@ -451,12 +451,12 @@ resource "null_resource" "supply_target_group_arns" {
       apiVersion: elbv2.k8s.aws/v1beta1
       kind: TargetGroupBinding
       metadata:
-        name:
+        name: ${lookup(var.target_groups[count.index], "name", "")}-tgb
       spec:
         serviceRef:
-          name: awesome-service # route traffic to the awesome-service
-          port: 80
-        targetGroupARN: ${var.alb_target_group_arns}
+          name: ${lookup(var.target_groups[count.index], "name", "")}
+          port: ${lookup(var.target_groups[count.index], "backend_port", "")}
+        targetGroupARN: ${lookup(var.target_groups[count.index], "target_group_arn", "")}
       YAML
     EOF
   }

--- a/variables.tf
+++ b/variables.tf
@@ -74,8 +74,8 @@ variable "alb_controller_depends_on" {
   description = "Resources that the module should wait for before starting the controller. For example if there is no node_group, 'aws_eks_fargate_profile.default'"
 }
 
-variable "alb_target_group_arns" {
+variable "target_groups" {
   description = "ARNs for existing load balancers that should be added via TargetGroupBindings. See https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/targetgroupbinding/targetgroupbinding/ for details"
-  type        = string
-  default     = ""
+  type        = any
+  default     = []
 }


### PR DESCRIPTION
This lets the user pass in objects for target group details to specify additional details required on the cr. 