### PR TITLE
Provides depends_on for data sources

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,7 @@ data "aws_caller_identity" "current" {}
 data "aws_eks_cluster" "selected" {
   count = var.k8s_cluster_type == "eks" ? 1 : 0
   name  = var.k8s_cluster_name
+  depends_on = [var.alb_controller_depends_on]
 }
 
 # Authentication data for that cluster

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ data "aws_eks_cluster" "selected" {
 data "aws_eks_cluster_auth" "selected" {
   count = var.k8s_cluster_type == "eks" ? 1 : 0
   name  = var.k8s_cluster_name
+  depends_on = [var.alb_controller_depends_on]
 }
 
 data "aws_iam_policy_document" "ec2_assume_role" {


### PR DESCRIPTION
In case you trying to deploy an ALB controller on EKS and you haven't yet deployed a k8s cluster itself, the module will fail with:

`Error: error reading EKS Cluster (cluster-name): ResourceNotFoundException: No cluster found for name: cluster-name.
{
  RespMetadata: {
    StatusCode: 404,
    RequestID: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
  },
  Message_: "No cluster found for name: cluster-name."
}`