### PR TITLE
fix: iam role can't be bigger than 64 chars

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -64,7 +64,7 @@ data "aws_iam_policy_document" "eks_oidc_assume_role" {
 }
 
 resource "aws_iam_role" "this" {
-  name        = "${var.aws_resource_name_prefix}${var.k8s_cluster_name}-aws-load-balancer-controller"
+  name        = substr("${var.aws_resource_name_prefix}${var.k8s_cluster_name}-aws-load-balancer-controller", 0, 64)
   description = "Permissions required by the Kubernetes AWS Load Balancer controller to do its job."
   path        = local.aws_iam_path_prefix
 


### PR DESCRIPTION
When the cluster name is too big....

we hit an issue that IAM role cant be bigger than 64 characters.


I think this is the documentation:
https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html

output:
```
╷
│ Error: expected length of name to be in the range (1 - 64), got k8s-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX-aws-load-balancer-controller
│ 
│   with module.eks-tools.module.alb_controller.aws_iam_role.this,
│   on .terraform/modules/eks-tools.alb_controller/main.tf line 67, in resource "aws_iam_role" "this":
│   67:   name        = "${var.aws_resource_name_prefix}${var.k8s_cluster_name}-aws-load-balancer-controller"
│ 
╵

```