### PR TITLE
Inconsistent error workaround

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -401,6 +401,9 @@ resource "kubernetes_cluster_role_binding" "this" {
   }
 }
 
+locals {
+  
+}
 resource "helm_release" "alb_controller" {
 
   name       = "aws-load-balancer-controller"
@@ -410,21 +413,34 @@ resource "helm_release" "alb_controller" {
   namespace  = var.k8s_namespace
   atomic     = true
   timeout    = 900
-  dynamic "set" {
-    for_each = {
-      "clusterName"           = var.k8s_cluster_name
-      "serviceAccount.create" = (var.k8s_cluster_type != "eks")
-      "serviceAccount.name"   = (var.k8s_cluster_type == "eks") ? kubernetes_service_account.this.metadata[0].name : null
-      "region"                = local.aws_region_name
-      "vpcId"                 = local.aws_vpc_id
-      "hostNetwork"           = var.enable_host_networking
-    }
-    content {
-      name  = set.key
-      value = set.value
-    }
-  }
-
+ # dynamic "set" {
+ #   for_each = {
+ #     "clusterName"           = var.k8s_cluster_name
+ #     "serviceAccount.create" = (var.k8s_cluster_type != "eks")
+ #     "serviceAccount.name"   = (var.k8s_cluster_type == "eks") ? kubernetes_service_account.this.metadata[0].name : null
+ #     "region"                = local.aws_region_name
+ #     "vpcId"                 = local.aws_vpc_id
+ #     "hostNetwork"           = var.enable_host_networking
+ #   }
+ #   content {
+ #     name  = set.key
+ #     value = set.value
+ #   }
+ # }
+  
+  
+  values = [
+    yamlencode({
+      "clusterName" : var.k8s_cluster_name,
+      "serviceAccount" : {
+        "create" : (var.k8s_cluster_type != "eks"),
+        "name":  (var.k8s_cluster_type == "eks") ? kubernetes_service_account.this.metadata[0].name : null
+      },
+      "region": local.aws_region_name,
+      "vpcId": local.aws_vpc_id
+      "hostNetwork":  var.enable_host_networking
+    })]
+  
   depends_on = [var.alb_controller_depends_on]
 }
 

--- a/main.tf
+++ b/main.tf
@@ -401,9 +401,6 @@ resource "kubernetes_cluster_role_binding" "this" {
   }
 }
 
-locals {
-  
-}
 resource "helm_release" "alb_controller" {
 
   name       = "aws-load-balancer-controller"
@@ -413,22 +410,6 @@ resource "helm_release" "alb_controller" {
   namespace  = var.k8s_namespace
   atomic     = true
   timeout    = 900
- # dynamic "set" {
- #   for_each = {
- #     "clusterName"           = var.k8s_cluster_name
- #     "serviceAccount.create" = (var.k8s_cluster_type != "eks")
- #     "serviceAccount.name"   = (var.k8s_cluster_type == "eks") ? kubernetes_service_account.this.metadata[0].name : null
- #     "region"                = local.aws_region_name
- #     "vpcId"                 = local.aws_vpc_id
- #     "hostNetwork"           = var.enable_host_networking
- #   }
- #   content {
- #     name  = set.key
- #     value = set.value
- #   }
- # }
-  
-  
   values = [
     yamlencode({
       "clusterName" : var.k8s_cluster_name,


### PR DESCRIPTION
When I tried to use the module with the latest aws-load-balancer-controller chart's version (at the moment of this writing), terraform's version 1.0.8 and terraform helm provider's version v2.3.0, it worked fine the first time, however, when I executed the terraform apply command again, it produced the following error:
Error: Provider produced inconsistent final plan.
The issue was solved when I added the updates in the PR in the fork.