### PR TITLE
Upgrade to v2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -91,24 +91,12 @@ resource "aws_iam_policy" "this" {
     {
       "Effect": "Allow",
       "Action": [
-        "iam:CreateServiceLinkedRole"
-      ],
-      "Resource": "*",
-      "Condition": {
-        "StringEquals": {
-            "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
-        }
-      }
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
+        "iam:CreateServiceLinkedRole",
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeAddresses",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInternetGateways",
         "ec2:DescribeVpcs",
-        "ec2:DescribeVpcPeeringConnections",
         "ec2:DescribeSubnets",
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeInstances",
@@ -191,8 +179,7 @@ resource "aws_iam_policy" "this" {
       "Resource": "arn:aws:ec2:*:*:security-group/*",
       "Condition": {
         "Null": {
-          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
-          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+          "aws:ResourceTag/ingress.k8s.aws/cluster": "false"
         }
       }
     },
@@ -237,7 +224,8 @@ resource "aws_iam_policy" "this" {
       "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
-        "elasticloadbalancing:RemoveTags"
+        "elasticloadbalancing:RemoveTags",
+        "elasticloadbalancing:DeleteTargetGroup"
       ],
       "Resource": [
         "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
@@ -246,8 +234,7 @@ resource "aws_iam_policy" "this" {
       ],
       "Condition": {
         "Null": {
-          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
-          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+          "aws:ResourceTag/ingress.k8s.aws/cluster": "false"
         }
       }
     },

--- a/main.tf
+++ b/main.tf
@@ -91,12 +91,24 @@ resource "aws_iam_policy" "this" {
     {
       "Effect": "Allow",
       "Action": [
-        "iam:CreateServiceLinkedRole",
+        "iam:CreateServiceLinkedRole"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+            "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "ec2:DescribeAccountAttributes",
         "ec2:DescribeAddresses",
         "ec2:DescribeAvailabilityZones",
         "ec2:DescribeInternetGateways",
         "ec2:DescribeVpcs",
+        "ec2:DescribeVpcPeeringConnections",
         "ec2:DescribeSubnets",
         "ec2:DescribeSecurityGroups",
         "ec2:DescribeInstances",
@@ -179,7 +191,8 @@ resource "aws_iam_policy" "this" {
       "Resource": "arn:aws:ec2:*:*:security-group/*",
       "Condition": {
         "Null": {
-          "aws:ResourceTag/ingress.k8s.aws/cluster": "false"
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
         }
       }
     },
@@ -224,8 +237,7 @@ resource "aws_iam_policy" "this" {
       "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
-        "elasticloadbalancing:RemoveTags",
-        "elasticloadbalancing:DeleteTargetGroup"
+        "elasticloadbalancing:RemoveTags"
       ],
       "Resource": [
         "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
@@ -234,7 +246,8 @@ resource "aws_iam_policy" "this" {
       ],
       "Condition": {
         "Null": {
-          "aws:ResourceTag/ingress.k8s.aws/cluster": "false"
+          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
+          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
         }
       }
     },

--- a/main.tf
+++ b/main.tf
@@ -179,8 +179,7 @@ resource "aws_iam_policy" "this" {
       "Resource": "arn:aws:ec2:*:*:security-group/*",
       "Condition": {
         "Null": {
-          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
-          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+          "aws:ResourceTag/ingress.k8s.aws/cluster": "false"
         }
       }
     },
@@ -225,7 +224,8 @@ resource "aws_iam_policy" "this" {
       "Effect": "Allow",
       "Action": [
         "elasticloadbalancing:AddTags",
-        "elasticloadbalancing:RemoveTags"
+        "elasticloadbalancing:RemoveTags",
+        "elasticloadbalancing:DeleteTargetGroup"
       ],
       "Resource": [
         "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
@@ -234,8 +234,7 @@ resource "aws_iam_policy" "this" {
       ],
       "Condition": {
         "Null": {
-          "aws:RequestTag/elbv2.k8s.aws/cluster": "true",
-          "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+          "aws:ResourceTag/ingress.k8s.aws/cluster": "false"
         }
       }
     },

--- a/variables.tf
+++ b/variables.tf
@@ -67,7 +67,7 @@ variable "aws_tags" {
 variable "aws_load_balancer_controller_chart_version" {
   description = "The AWS Load Balancer Controller version to use. See https://github.com/aws/eks-charts/releases/ and https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases for available versions"
   type        = string
-  default     = "2.3.1"
+  default     = "v2.3.1"
 }
 
 variable "alb_controller_depends_on" {

--- a/variables.tf
+++ b/variables.tf
@@ -67,7 +67,7 @@ variable "aws_tags" {
 variable "aws_load_balancer_controller_chart_version" {
   description = "The AWS Load Balancer Controller version to use. See https://github.com/aws/eks-charts/releases/ and https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases for available versions"
   type        = string
-  default     = "v2.3.1"
+  default     = "1.3.3"
 }
 
 variable "alb_controller_depends_on" {

--- a/variables.tf
+++ b/variables.tf
@@ -67,7 +67,7 @@ variable "aws_tags" {
 variable "aws_load_balancer_controller_chart_version" {
   description = "The AWS Load Balancer Controller version to use. See https://github.com/aws/eks-charts/releases/ and https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases for available versions"
   type        = string
-  default     = "1.2.6"
+  default     = "2.3.1"
 }
 
 variable "alb_controller_depends_on" {


### PR DESCRIPTION
Related to https://app.zenhub.com/workspaces/datagov-devsecops-579a2532d1d6ea9c3fcf5cfa/issues/gsa/datagov-deploy/3617

Followed instructions from:
- https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/deploy/upgrade/migrate_v1_v2/
- https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.3/deploy/installation/
- https://github.com/kubernetes-sigs/aws-load-balancer-controller