### PR TITLE
Don't use deprected template provider

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -449,8 +449,8 @@ resource "helm_release" "alb_controller" {
 }
 
 # Generate a kubeconfig file for the EKS cluster to use in provisioners
-data "template_file" "kubeconfig" {
-  template = <<-EOF
+locals {
+  kubeconfig = <<-EOF
     apiVersion: v1
     kind: Config
     current-context: terraform
@@ -485,7 +485,7 @@ resource "null_resource" "supply_target_group_arns" {
   count = (length(var.target_groups) > 0) ? length(var.target_groups) : 0
 
   triggers = {
-    kubeconfig  = base64encode(data.template_file.kubeconfig.rendered)
+    kubeconfig  = base64encode(local.kubeconfig)
     cmd_create  = <<-EOF
       cat <<YAML | kubectl -n ${var.k8s_namespace} --kubeconfig <(echo $KUBECONFIG | base64 --decode) apply -f -
       apiVersion: elbv2.k8s.aws/v1beta1


### PR DESCRIPTION
The template provider was archived and should be replaced by other
alternatives:

https://github.com/hashicorp/terraform-provider-template/issues/85

I used a here-document with variable interpolation.

The main motivation is that the provider is not available for all
platforms (especially arm64 which is being used by modern macs)