### PR TITLE
Add required_providers

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,8 @@
 terraform {
+  required_providers {
+    kubernetes = ">= 2.8.0"
+    helm = ">=2.4.1"
+  }
+
   required_version = ">= 0.12"
 }


### PR DESCRIPTION
Testing it locally at least, the module doesn't work with this explicit

`required_providers` 

The docs state as well that `required_providers` must be listet. I went for the 0.12-compatible syntax