### PR TITLE
Update ALB Controller v2.6.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -90,7 +90,9 @@ resource "aws_iam_policy" "this" {
     "Statement": [
         {
             "Effect": "Allow",
-            "Action": "iam:CreateServiceLinkedRole",
+            "Action": [
+                "iam:CreateServiceLinkedRole"
+            ],
             "Resource": "*",
             "Condition": {
                 "StringEquals": {
@@ -278,6 +280,28 @@ resource "aws_iam_policy" "this" {
             "Condition": {
                 "Null": {
                     "aws:ResourceTag/elbv2.k8s.aws/cluster": "false"
+                }
+            }
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "elasticloadbalancing:AddTags"
+            ],
+            "Resource": [
+                "arn:aws:elasticloadbalancing:*:*:targetgroup/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/net/*/*",
+                "arn:aws:elasticloadbalancing:*:*:loadbalancer/app/*/*"
+            ],
+            "Condition": {
+                "StringEquals": {
+                    "elasticloadbalancing:CreateAction": [
+                        "CreateTargetGroup",
+                        "CreateLoadBalancer"
+                    ]
+                },
+                "Null": {
+                    "aws:RequestTag/elbv2.k8s.aws/cluster": "false"
                 }
             }
         },

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ resource "aws_iam_policy" "this" {
   path        = local.aws_iam_path_prefix
   # We use a heredoc for the policy JSON so that we can more easily diff and
   # copy/paste from upstream. Ignore whitespace when you diff to more easily see the changes!
-  # Source: `curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.3.1/docs/install/iam_policy.json`
+  # Source: `curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.6.1/docs/install/iam_policy.json`
   policy = <<-POLICY
 {
     "Version": "2012-10-17",

--- a/variables.tf
+++ b/variables.tf
@@ -67,7 +67,7 @@ variable "aws_tags" {
 variable "aws_load_balancer_controller_chart_version" {
   description = "The AWS Load Balancer Controller version to use. See https://github.com/aws/eks-charts/releases/ and https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases for available versions"
   type        = string
-  default     = "1.3.3"
+  default     = "2.6.1"
 }
 
 variable "alb_controller_depends_on" {


### PR DESCRIPTION
Related to
- https://github.com/GSA-TTS/datagov-brokerpak-eks/pull/112

Notes:
- Use the latest version of the Helm `aws-load-balancer-controller` v1.6.1
  - Use the latest version of the AWS ALB Controller v2.6.1
- Important Changelog notes:
  - https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.5.0


References:
- [Helm to Controller spec](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/helm/aws-load-balancer-controller/Chart.yaml)
- [ALB Controller v2.6 Docs](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.6/deploy/installation/#deployment-considerations)
- [New v2.6.1 Controller IAM Policy](https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.6.1/docs/install/iam_policy.json)